### PR TITLE
Remove listing compatible iOS and Xcode version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Once you signed a commercial license, register your app bundle identifier at [cu
 To get started with PSPDFKit Instant we suggest reading the [Integrating PSPDFKit](https://pspdfkit.com/guides/ios/current/getting-started/integrating-pspdfkit) page located
 at the [PSPDFKit Guides](https://pspdfkit.com/guides/ios/current/).
 
-PSPDFKit is compatible with iOS 13, 14, and 15 and Xcode 13+.
-
 ## Support
 
 For questions or to report issues, open a ticket on our [support platform](https://pspdfkit.com/support/request).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Once you signed a commercial license, register your app bundle identifier at [cu
 To get started with PSPDFKit Instant we suggest reading the [Integrating PSPDFKit](https://pspdfkit.com/guides/ios/current/getting-started/integrating-pspdfkit) page located
 at the [PSPDFKit Guides](https://pspdfkit.com/guides/ios/current/).
 
+See [System Compatibility for iOS](https://pspdfkit.com/guides/ios/announcements/version-support/) for more information on supported operating systems.
+
 ## Support
 
 For questions or to report issues, open a ticket on our [support platform](https://pspdfkit.com/support/request).


### PR DESCRIPTION
This PR removes listing the compatible iOS and Xcode version of PSPDFKit Instant, as those are seen in the guides as well.