### PR TITLE
Update platform requirements to iOS 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Nutrient Instant",
     platforms: [
-        .iOS(.v15),
-        .macCatalyst(.v15),
+        .iOS(.v16),
+        .macCatalyst(.v16),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
This updates the required iOS and Mac Catalyst version to iOS 16 as Nutrient iOS SDK 14.2.0 removed support for iOS 15.